### PR TITLE
Removed .form-control class from degree picker select's

### DIFF
--- a/includes/degree-search-functions.php
+++ b/includes/degree-search-functions.php
@@ -13,15 +13,15 @@ if ( ! function_exists( 'ucf_degree_picker_inline_layout' ) ) {
 		<form class="form" action="" method="GET" data-degree-picker>
 			<div class="row">
 				<label class="sr-only" for="sel_program_type">Select Program Type</label>
-				<select class="custom-select form-control col-12 col-md mb-2 text-uppercase" id="sel_program_type" name="sel_program_type">
+				<select class="custom-select col-12 col-md mb-2 text-uppercase" id="sel_program_type" name="sel_program_type">
 					<option value="" selected>Degree Level</option>
 				</select>
 				<label class="sr-only" for="sel_interest">Select an Area of Interest</label>
-				<select class="custom-select form-control col-12 col-md mb-2 text-uppercase" id="sel_interest" name="sel_interest" disabled>
+				<select class="custom-select col-12 col-md mb-2 text-uppercase" id="sel_interest" name="sel_interest" disabled>
 					<option value="" selected>Interest</option>
 				</select>
 				<label class="sr-only" for="sel_program">Select Program</label>
-				<select class="custom-select form-control col-12 col-md mb-2 text-uppercase" id="sel_program" name="sel_program" disabled>
+				<select class="custom-select col-12 col-md mb-2 text-uppercase" id="sel_program" name="sel_program" disabled>
 					<option value="" selected>Program</option>
 				</select>
 				<button type="submit" class="col-12 col-md-2 col-lg-1 btn btn-primary h-100" name="submit" disabled aria-label="View Program"><span class="hidden-md-up" aria-hidden="true">View Program</span> <span class="fa fa-arrow-right" aria-hidden="true"></span></button>


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Removes the `.form-control` class from degree picker `<select>`'s.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows alignment fixes added in Athena v1.0.1 to take effect properly.  Resolves #23.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Can be reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
