### PR TITLE
Prevent duplicate degree search initialization

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -49,3 +49,6 @@ if ( filter_var( get_option( 'ucf_post_list_include_js' ), FILTER_VALIDATE_BOOLE
 if ( filter_var( get_option( 'ucf_degree_search_include_typeahead' ), FILTER_VALIDATE_BOOLEAN ) !== false ) {
 	update_option( 'ucf_degree_search_include_typeahead', false );
 }
+if ( filter_var( get_option( 'ucf_degree_search_auto_initialize' ), FILTER_VALIDATE_BOOLEAN ) !== false ) {
+	update_option( 'ucf_degree_search_auto_initialize', false );
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a forced option override to the child theme to prevent degree search typeaheads from auto-initializing using the plugin's provided js, since the child theme provides its own initialization logic.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes duplicate typeaheads on sites that haven't manually set this option to false/unchecked.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Can be reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
