### PR TITLE
Force tuition plan code field

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -241,6 +241,6 @@ add_action( 'admin_menu', 'hide_admin_links' );
 
 // Force Tuition and Fees plugin to use 'degree_code' field for
 // a single degree's degree plan code value
-if ( filter_var( get_option( 'ucf_tuition_fees_degree_plan_code_name' ), FILTER_VALIDATE_BOOLEAN ) !== 'degree_code' ) {
+if ( get_option( 'ucf_tuition_fees_degree_plan_code_name' ) !== 'degree_code' ) {
 	update_option( 'ucf_tuition_fees_degree_plan_code_name', 'degree_code' );
 }

--- a/includes/config.php
+++ b/includes/config.php
@@ -232,3 +232,15 @@ function hide_admin_links() {
 	remove_menu_page( 'edit-comments.php' );
 }
 add_action( 'admin_menu', 'hide_admin_links' );
+
+
+/**
+ * Force update various plugin settings that are directly tied
+ * to theme-controlled options or meta fields
+ */
+
+// Force Tuition and Fees plugin to use 'degree_code' field for
+// a single degree's degree plan code value
+if ( filter_var( get_option( 'ucf_tuition_fees_degree_plan_code_name' ), FILTER_VALIDATE_BOOLEAN ) !== 'degree_code' ) {
+	update_option( 'ucf_tuition_fees_degree_plan_code_name', 'degree_code' );
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Forces the Tuition and Fees Plugin's "Degree Plan Code meta name" value to `degree_code` for backwards compatibility with Online's existing plan code field name.

I am open to moving this to the Online Utilities plugin instead if anyone feels strongly about it--I thought it made sense to put it here since it directly ties to a post meta field, which is controlled by the theme, but I'm cool with either option.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Necessary for tuition imports to run properly on Online.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev--attempts to modify the value and save should result in the value being unchanged upon save.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
