### PR TITLE
Added underline hover state to default post list layout items

### DIFF
--- a/includes/post-list-functions.php
+++ b/includes/post-list-functions.php
@@ -43,9 +43,9 @@ function online_post_list_display_default( $content, $posts, $atts ) {
 			}
 		?>
 			<article class="col-12 col-lg mb-4 mb-lg-5 ucf-post-list-item">
-				<a class="d-block text-secondary text-decoration-none" href="<?php echo get_permalink( $item->ID ); ?>">
+				<a class="d-block text-secondary" href="<?php echo get_permalink( $item->ID ); ?>">
 					<?php if ( $item_img ) : ?>
-					<div class="ucf-post-list-thumbnail-block media-background-container mb-4">
+					<div class="ucf-post-list-thumbnail-block text-decoration-none media-background-container mb-4">
 						<img src="<?php echo $item_img; ?>" class="ucf-post-list-thumbnail-image media-background object-fit-cover" alt="">
 					</div>
 					<?php endif; ?>


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
A handy-dandy two line class swapout to apply a hover state to the 'default' post list layout's article titles.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An underline on hover helps the user understand the thumbnail + title link is clickable.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
