### PR TITLE
Updated expected page slug for Bachelors programs page

### DIFF
--- a/includes/degree-search-functions.php
+++ b/includes/degree-search-functions.php
@@ -70,7 +70,7 @@ add_filter( 'ucf_degree_search_suggestion', 'online_degree_search_suggestion', 1
  * @return string
  */
 function online_degree_search_footer() {
-	$majors = get_page_by_path( 'majors' );
+	$majors = get_page_by_path( 'bachelors' );
 	$masters = get_page_by_path( 'masters' );
 	$docorates = get_page_by_path( 'doctorates' );
 	$certificates = get_page_by_path( 'certificates' );

--- a/includes/degree-search-functions.php
+++ b/includes/degree-search-functions.php
@@ -70,17 +70,17 @@ add_filter( 'ucf_degree_search_suggestion', 'online_degree_search_suggestion', 1
  * @return string
  */
 function online_degree_search_footer() {
-	$majors = get_page_by_path( 'bachelors' );
+	$bachelors = get_page_by_path( 'bachelors' );
 	$masters = get_page_by_path( 'masters' );
-	$docorates = get_page_by_path( 'doctorates' );
+	$doctorates = get_page_by_path( 'doctorates' );
 	$certificates = get_page_by_path( 'certificates' );
 	ob_start();
 ?>
 	<div class="dropdown-divider"></div>
 	<p class="ucf-degree-search-suggestion ml-3 mt-3 mb-2 font-weight-bold">What kind of degree are you interested in?</p>
-	<a href="<?php echo get_permalink( $majors->ID ); ?>" class="ucf-degree-search-suggestion tt-suggestion tt-selectable">Bachelor</a>
+	<a href="<?php echo get_permalink( $bachelors->ID ); ?>" class="ucf-degree-search-suggestion tt-suggestion tt-selectable">Bachelor</a>
 	<a href="<?php echo get_permalink( $masters->ID ); ?>" class="ucf-degree-search-suggestion tt-suggestion tt-selectable">Master</a>
-	<a href="<?php echo get_permalink( $docorates->ID ); ?>" class="ucf-degree-search-suggestion tt-suggestion tt-selectable">Doctorate</a>
+	<a href="<?php echo get_permalink( $doctorates->ID ); ?>" class="ucf-degree-search-suggestion tt-suggestion tt-selectable">Doctorate</a>
 	<a href="<?php echo get_permalink( $certificates->ID ); ?>" class="ucf-degree-search-suggestion tt-suggestion tt-selectable">Certificate</a>
 <?php
 	return ob_get_clean();


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Modifies the expected page slug for the top-level Bachelors/Majors programs page.  See also: https://github.com/UCF/Online-Utilities/pull/8

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The program page slug is changing from /majors/ to /bachelors/; the link to this page included in the degree typeahead footer will be broken without this update.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in dev--search for anything that returns results, and click the "Bachelors" link under "What type of degree are you interested in?"; it should direct to /bachelors/. 

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
