### PR TITLE
Added sorting utility for any get_terms requests for program types

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -15,8 +15,8 @@ define( 'ONLINE_THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 define( 'ONLINE_DEGREE_PROGRAM_ORDER', serialize( array(
 	'online-major',
 	'online-master',
-	'online-doctorate',
-	'online-certificate'
+	'online-certificate',
+	'online-doctorate'
 ) ) );
 
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -84,3 +84,38 @@ function online_get_post_choices( $post_type='post', $args=array() ) {
 
 	return $retval;
 }
+
+
+/**
+ * Filter for get_terms hook that, by default, sorts any
+ * program_types term queries by the ONLINE_DEGREE_PROGRAM_ORDER sort order.
+ *
+ * Allows program types displayed in the degree picker interface to be
+ * sorted as expected. Also applies anywhere get_terms() is called.
+ *
+ * @author Jo Dickson
+ * @since 1.0.0
+ */
+function online_program_types_terms_sorting( $terms, $taxonomies, $args, $term_query ) {
+	// Only perform sorting if this is a query exclusively
+	// for program_types terms
+	if ( $taxonomies === array( 'program_types' ) ) {
+		$term_slugs = unserialize( ONLINE_DEGREE_PROGRAM_ORDER );
+		$items_sorted = array_fill_keys( $term_slugs, false );
+
+		foreach ( $terms as $term ) {
+			$items_sorted[$term->slug] = $term;
+		}
+
+		// Replace associative keys with numeric keys
+		$items_sorted = array_values( $items_sorted );
+
+		// Remove any empty sorted items
+		$items_sorted = array_filter( $items_sorted );
+
+		$terms = $items_sorted;
+	}
+	return $terms;
+}
+
+add_filter( 'get_terms', 'online_program_types_terms_sorting', 10, 4 );


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Updates the order of terms in `ONLINE_DEGREE_PROGRAM_ORDER` as requested.
- Enforces the sort order for program types defined in `ONLINE_DEGREE_PROGRAM_ORDER` when program type terms are queried via `get_terms()`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures the desired program type sort order is applied to the degree picker's program type dropdown.  Will also apply anywhere else `get_terms()` is called for `program_types` terms.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
