### PR TITLE
Made resident and nonresident tuition fields editable

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1483,7 +1483,7 @@
                 "key": "field_596e47d3ed1fc",
                 "label": "Resident Tuition",
                 "name": "degree_resident_tuition",
-                "type": "read_only",
+                "type": "text",
                 "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
@@ -1492,14 +1492,17 @@
                     "class": "",
                     "id": ""
                 },
-                "copy_to_clipboard": 0,
-                "display_type": "text"
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
             },
             {
                 "key": "field_596e47e6ed1fd",
                 "label": "Nonresident Tuition",
                 "name": "degree_nonresident_tuition",
-                "type": "read_only",
+                "type": "text",
                 "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
@@ -1508,8 +1511,11 @@
                     "class": "",
                     "id": ""
                 },
-                "copy_to_clipboard": 0,
-                "display_type": "text"
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
             },
             {
                 "key": "field_596f740d354f1",


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows for custom overriding of resident and nonresident tuition values with recent updates to the Degree CPT plugin and Tuition and Fees plugin.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Field changes are uploaded in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly.**

** With this update, we no longer require the ACF Read-Only Fields plugin to be installed with this site.  I've updated the wiki docs with this change already.
