### PR TITLE
Fixed broken conditional logic on page_header_title field

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -110,18 +110,18 @@
                 "return_format": "value"
             },
             {
-                "key": "field_58fe096728bcc",
+                "key": "field_5c5b31bf100c8",
                 "label": "Header Title Text",
                 "name": "page_header_title",
                 "type": "text",
-                "instructions": "Overrides the page title.",
+                "instructions": "(Optional) Title text to display in the header.  The page title will be used if left blank.",
                 "required": 0,
                 "conditional_logic": [
                     [
                         {
                             "field": "field_59aed971c187c",
                             "operator": "==",
-                            "value": "title_subtitle"
+                            "value": "default"
                         }
                     ]
                 ],


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Fixed broken conditional logic on the custom Header Title Text field, which lets you override the page title text in the h1.  Previously, it would not display, even if the "Header Content - Type of Content" field was set to "default".

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The field wasn't showing up.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Can be verified in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
