### PR TITLE
Add an attribute for the 'select' layout label's classes

### DIFF
--- a/includes/post-list-functions.php
+++ b/includes/post-list-functions.php
@@ -230,7 +230,7 @@ function online_post_list_display_select( $content, $posts, $atts ) {
 ?>
 	<?php if ( $posts ) : ?>
 		<form action="#" id="ucf-post-list-select-form-<?php echo $atts['list_id']; ?>" class="d-flex align-items-end" data-post-list-form>
-			<div class="mr-2">
+			<div class="mr-2 w-100">
 				<label <?php echo $label_classes; ?> for="ucf-post-list-select-<?php echo $atts['list_id']; ?>"><?php echo $atts['select_layout__label_text']; ?></label>
 				<select class="ucf-post-list-select custom-select form-control" id="ucf-post-list-select-<?php echo $atts['list_id']; ?>" data-post-list-select>
 					<option value="" selected disabled><?php echo $atts['select_layout__option_text']; ?></option>

--- a/includes/post-list-functions.php
+++ b/includes/post-list-functions.php
@@ -31,6 +31,7 @@ function online_post_list_sc_atts( $atts, $layout ) {
 		$atts['link_layout__link_classes']  = 'mb-3 mb-lg-4';
 	} elseif ( $layout === 'select' ) {
 		$atts['select_layout__label_text']  = 'Select an Option';
+		$atts['select_layout__label_classes']  = '';
 		$atts['select_layout__option_text'] = 'Select an Option';
 		$atts['select_layout__button_text'] = 'Go';
 	}
@@ -229,7 +230,7 @@ function online_post_list_display_select( $content, $posts, $atts ) {
 	<?php if ( $posts ) : ?>
 		<form action="#" id="ucf-post-list-select-form-<?php echo $atts['list_id']; ?>" class="d-flex align-items-end" data-post-list-form>
 			<div class="mr-2">
-				<label for="ucf-post-list-select-<?php echo $atts['list_id']; ?>"><?php echo $atts['select_layout__label_text']; ?></label>
+				<label class="<?php echo $atts['select_layout__label_classes']; ?>" for="ucf-post-list-select-<?php echo $atts['list_id']; ?>"><?php echo $atts['select_layout__label_text']; ?></label>
 				<select class="ucf-post-list-select custom-select form-control" id="ucf-post-list-select-<?php echo $atts['list_id']; ?>" data-post-list-select>
 					<option value="" selected disabled><?php echo $atts['select_layout__option_text']; ?></option>
 					<?php foreach ( $posts as $item ) : ?>

--- a/includes/post-list-functions.php
+++ b/includes/post-list-functions.php
@@ -225,12 +225,13 @@ add_filter( 'ucf_post_list_display_select_before', 'online_post_list_display_sel
 
 function online_post_list_display_select( $content, $posts, $atts ) {
 	if ( $posts && ! is_array( $posts ) ) { $posts = array( $posts ); }
+	$label_classes = !empty( $atts['select_layout__label_classes'] ) ? 'class="' . $atts['select_layout__label_classes'] . '"' : '';
 	ob_start();
 ?>
 	<?php if ( $posts ) : ?>
 		<form action="#" id="ucf-post-list-select-form-<?php echo $atts['list_id']; ?>" class="d-flex align-items-end" data-post-list-form>
 			<div class="mr-2">
-				<label class="<?php echo $atts['select_layout__label_classes']; ?>" for="ucf-post-list-select-<?php echo $atts['list_id']; ?>"><?php echo $atts['select_layout__label_text']; ?></label>
+				<label <?php echo $label_classes; ?> for="ucf-post-list-select-<?php echo $atts['list_id']; ?>"><?php echo $atts['select_layout__label_text']; ?></label>
 				<select class="ucf-post-list-select custom-select form-control" id="ucf-post-list-select-<?php echo $atts['list_id']; ?>" data-post-list-select>
 					<option value="" selected disabled><?php echo $atts['select_layout__option_text']; ?></option>
 					<?php foreach ( $posts as $item ) : ?>


### PR DESCRIPTION
**Description**
Adds the `select_layout__label_classes` custom attribute for the new Select layout's label element.

**Motivation and Context**
Allows us to add classes to the label element for either styling purposes or to apply the `sr-only` class (which is what we need to do for the Online Student Resources page label element).

**How Has This Been Tested?**
Changes are viewable in dev.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly. _The documentation for these changes will be added to the wiki with the other information about the new Post List Shortcode layouts (#68)_
