### PR TITLE
Only filter and rewrite permalinks if the post's status is 'publish'

### DIFF
--- a/includes/resources-functions.php
+++ b/includes/resources-functions.php
@@ -12,7 +12,7 @@
  */
 
 function online_resources_cat_post_replace_link( $url, $post ) {
-	if ( $post && $post->post_type === 'post' ) {
+	if ( $post && $post->post_type === 'post' && $post->post_status === 'publish' ) {
 		if ( has_category( 'resources', $post ) ) {
 			return home_url( 'student-resources/' . $post->post_name );
 		} else {
@@ -43,8 +43,10 @@ function online_resources_cat_rewrite_rule() {
 	) );
 
 	if ( $resources ) {
-		foreach ( $resources as $resources ) {
-			add_rewrite_rule( 'student-resources/([^/]+)/?$', 'index.php?post_type=post&name=$matches[1]', 'top' );
+		foreach ( $resources as $resource ) {
+			if ( $resource->post_status === 'publish' ) {
+				add_rewrite_rule( 'student-resources/([^/]+)/?$', 'index.php?post_type=post&name=$matches[1]', 'top' );
+			}
 		}
 	}
 }

--- a/includes/vertical-functions.php
+++ b/includes/vertical-functions.php
@@ -275,7 +275,7 @@ add_filter( 'acf/fields/post_object/query/name=post_vertical', 'online_related_v
  */
 
 function online_vertical_person_replace_link( $url, $post ) {
-	if ( $post && $post->post_type === 'person' ) {
+	if ( $post && $post->post_type === 'person' && $post->post_status === 'publish' ) {
 		$vertical_id = online_get_post_vertical_id( $post );
 		if ( !$vertical_id ) { return $url; }
 
@@ -308,7 +308,7 @@ add_filter( 'post_type_link', 'online_vertical_person_replace_link', 1, 2 );
  */
 
 function online_vertical_post_replace_link( $url, $post ) {
-	if ( $post && $post->post_type === 'post' ) {
+	if ( $post && $post->post_type === 'post' && $post->post_status === 'publish' ) {
 		$vertical_id = online_get_post_vertical_id( $post );
 		if ( !$vertical_id ) { return $url; }
 
@@ -350,11 +350,13 @@ function online_verticals_rewrite_rule() {
 
 	if ( $verticals ) {
 		foreach ( $verticals as $vertical ) {
-			// People
-			add_rewrite_rule( $vertical->post_name . '/person/([^/]+)/?$', 'index.php?post_type=person&name=$matches[1]', 'bottom' );
+			if ( $vertical->post_status === 'publish' ) {
+				// People
+				add_rewrite_rule( $vertical->post_name . '/person/([^/]+)/?$', 'index.php?post_type=person&name=$matches[1]', 'bottom' );
 
-			// Posts (news)
-			add_rewrite_rule( $vertical->post_name . '/news/([^/]+)/?$', 'index.php?post_type=post&name=$matches[1]', 'bottom' );
+				// Posts (news)
+				add_rewrite_rule( $vertical->post_name . '/news/([^/]+)/?$', 'index.php?post_type=post&name=$matches[1]', 'bottom' );
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Description**
Updated the Resources post and Vertical-assigned people and post URL filters and rewrites to only get executed if the post's status is set to `publish`

**Motivation and Context**
Previews of post drafts were 404ing since the slugs are not assigned until after they're published.

**How Has This Been Tested?**
Testing and viewable in QA.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
