### PR TITLE
Add Tuition Details Fields and Markup for Degree Pages

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -2268,6 +2268,58 @@
                 "maxlength": ""
             },
             {
+                "key": "field_5d810d55cefa1",
+                "label": "Tuition Details",
+                "name": "degree_tuition_details",
+                "type": "group",
+                "instructions": "Displayed below the tuition amount in both the 'In State' and 'Out of State' panels.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layout": "block",
+                "sub_fields": [
+                    {
+                        "key": "field_5d810d95cefa2",
+                        "label": "Tuition Details Text",
+                        "name": "degree_tuition_details_text",
+                        "type": "text",
+                        "instructions": "The text to display under the tuition amount.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "50",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5d810daecefa3",
+                        "label": "Tuition Details Link",
+                        "name": "degree_tuition_details_link",
+                        "type": "url",
+                        "instructions": "If this field is set, the 'Tuition Details Text' will be linked to this URL.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "50",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": ""
+                    }
+                ]
+            },
+            {
                 "key": "field_5bdc5aa3cd682",
                 "label": "Documents, Media and More",
                 "name": "",

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -113,6 +113,7 @@ function online_get_degree_hours_markup( $degree ) {
 function online_get_degree_tuition_markup( $degree ) {
 	$resident_tuition    = online_format_tuition_value( $degree->degree_resident_tuition );
 	$nonresident_tuition = online_format_tuition_value( $degree->degree_nonresident_tuition );
+	$tuition_details     = get_field( 'degree_tuition_details', $degree );
 
 	ob_start();
 	if ( $resident_tuition || $nonresident_tuition ):
@@ -148,6 +149,17 @@ function online_get_degree_tuition_markup( $degree ) {
 			<div class="tab-pane fade <?php if ( ! $resident_tuition ){ ?>show active<?php } ?>" id="nonresident-tuition" role="tabpanel" aria-labelledby="nonresident-tuition-tab">
 				<?php echo $nonresident_tuition; ?>
 			</div>
+			<?php endif; ?>
+
+			<?php if ( ! empty( $tuition_details ) ) :
+				$tuition_details_link = $tuition_details['degree_tuition_details_link'];
+				$tuition_details_text = $tuition_details['degree_tuition_details_text'];
+
+				if ( $tuition_details_text && $tuition_details_link ): ?>
+				<a class="small mt-2 mt-md-3" href="<?php echo $tuition_details_link; ?>"><?php echo $tuition_details_text; ?></a>
+				<?php elseif ( $tuition_details_text ): ?>
+				<span class="small mt-2 mt-md-3"><?php echo $tuition_details_text; ?></span>
+				<?php endif; ?>
 			<?php endif; ?>
 		</div>
 	</div>

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -113,7 +113,10 @@ function online_get_degree_hours_markup( $degree ) {
 function online_get_degree_tuition_markup( $degree ) {
 	$resident_tuition    = online_format_tuition_value( $degree->degree_resident_tuition );
 	$nonresident_tuition = online_format_tuition_value( $degree->degree_nonresident_tuition );
-	$tuition_details     = get_field( 'degree_tuition_details', $degree );
+
+	$tuition_details      = get_field( 'degree_tuition_details', $degree );
+	$tuition_details_link = $tuition_details['degree_tuition_details_link'];
+	$tuition_details_text = $tuition_details['degree_tuition_details_text'];
 
 	ob_start();
 	if ( $resident_tuition || $nonresident_tuition ):
@@ -151,15 +154,10 @@ function online_get_degree_tuition_markup( $degree ) {
 			</div>
 			<?php endif; ?>
 
-			<?php if ( ! empty( $tuition_details ) ) :
-				$tuition_details_link = $tuition_details['degree_tuition_details_link'];
-				$tuition_details_text = $tuition_details['degree_tuition_details_text'];
-
-				if ( $tuition_details_text && $tuition_details_link ): ?>
-				<a class="small mt-2 mt-md-3" href="<?php echo $tuition_details_link; ?>"><?php echo $tuition_details_text; ?></a>
-				<?php elseif ( $tuition_details_text ): ?>
-				<span class="small mt-2 mt-md-3"><?php echo $tuition_details_text; ?></span>
-				<?php endif; ?>
+			<?php if ( $tuition_details_link && $tuition_details_text ) : ?>
+			<a class="small mt-2 mt-md-3" href="<?php echo $tuition_details_link; ?>"><?php echo $tuition_details_text; ?></a>
+			<?php elseif ( $tuition_details_text ): ?>
+			<span class="small mt-2 mt-md-3"><?php echo $tuition_details_text; ?></span>
 			<?php endif; ?>
 		</div>
 	</div>


### PR DESCRIPTION
**Description**
Adds 'Tuition Details' ACF fields and markup to the 'Program at a Glance' tuition block.

**Motivation and Context**
The Online team wanted to have a way to add a small blurb under the 'cost per credit hour' text in the Tuition block.

**How Has This Been Tested?**
Changes are viewable in dev. See links in Slack.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
