### PR TITLE
Adds Course Duration Fields and Markup to Degree Pages

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -2211,6 +2211,115 @@
                 "maxlength": ""
             },
             {
+                "key": "field_5d828f8086c46",
+                "label": "Degree Duration",
+                "name": "degree_duration",
+                "type": "group",
+                "instructions": "This information will be displayed in the same block as the 'Credit Hours' information.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layout": "block",
+                "sub_fields": [
+                    {
+                        "key": "field_5d829c93ab465",
+                        "label": "Font Icon Classes",
+                        "name": "degree_duration_font_icon_classes",
+                        "type": "text",
+                        "instructions": "The font icon to display above either the credit hours or duration amount. Defaults to: 'fa fa-3x fa-desktop'.\r\n\r\nAdd classes, separated by a single space, for a supported font icon (e.g. <a href=\"https:\/\/fontawesome.com\/v4.7.0\/icons\/\" target=\"_blank\">Font Awesome<\/a>) to display.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5d828f9a86c47",
+                        "label": "Amount",
+                        "name": "degree_duration_amount",
+                        "type": "number",
+                        "instructions": "The numerical amount to display for this degree's duration. Must be a number.\r\n\r\nIf this value is entered, the amount, descriptor and notice will be displayed in place of the 'Credit Hours' information, and move the 'Credit Hours' line to a single line at the bottom of the card.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "min": "",
+                        "max": "",
+                        "step": ""
+                    },
+                    {
+                        "key": "field_5d828fb986c48",
+                        "label": "Amount Descriptor",
+                        "name": "degree_duration_descriptor",
+                        "type": "text",
+                        "instructions": "The amount descriptor for the degree duration. Defaults to 'Months'.",
+                        "required": 1,
+                        "conditional_logic": [
+                            [
+                                {
+                                    "field": "field_5d828f9a86c47",
+                                    "operator": "!=empty"
+                                }
+                            ]
+                        ],
+                        "wrapper": {
+                            "width": "50",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "Months",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5d828fe886c49",
+                        "label": "Notice",
+                        "name": "degree_duration_notice",
+                        "type": "text",
+                        "instructions": "The notice that is showed below the amount descriptor. Defaults to 'Approx. program length'.",
+                        "required": 1,
+                        "conditional_logic": [
+                            [
+                                {
+                                    "field": "field_5d828f9a86c47",
+                                    "operator": "!=empty"
+                                }
+                            ]
+                        ],
+                        "wrapper": {
+                            "width": "50",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "Approx. program length",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    }
+                ]
+            },
+            {
                 "key": "field_596e47d3ed1fc",
                 "label": "Resident Tuition",
                 "name": "degree_resident_tuition",

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -87,7 +87,7 @@ function online_get_degree_duration_markup( $degree ) {
 	$credit_hours      = get_field( 'degree_hours', $degree );
 	$duration          = get_field( 'degree_duration', $degree );
 	$is_duration_set   = !empty( $duration['degree_duration_amount'] );
-	$font_icon_classes = ( $duration['degree_duration_font_icon_classes'] ?: 'fa fa-3x fa-desktop' );
+	$font_icon_classes = $duration['degree_duration_font_icon_classes'] ?: 'fa fa-3x fa-desktop';
 
 	ob_start();
 	if ( $credit_hours ):
@@ -97,8 +97,8 @@ function online_get_degree_duration_markup( $degree ) {
 			<span class="<?php echo $font_icon_classes; ?> text-primary mb-2" aria-hidden="true"></span>
 			<?php if ( $credit_hours && $is_duration_set ):
 				$duration_amount     = $duration['degree_duration_amount'];
-				$duration_descriptor = ( $duration['degree_duration_descriptor'] ?: 'Months' );
-				$duration_notice     = ( $duration['degree_duration_notice'] ?: 'Approx. program length' );
+				$duration_descriptor = $duration['degree_duration_descriptor'] ?: 'Months';
+				$duration_notice     = $duration['degree_duration_notice'] ?: 'Approx. program length';
 			?>
 			<strong class="d-block display-4"><?php echo $duration_amount; ?></strong>
 			<span class="d-block text-uppercase text-nowrap font-weight-bold"><?php echo $duration_descriptor; ?></span>

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -103,7 +103,7 @@ function online_get_degree_duration_markup( $degree ) {
 			<strong class="d-block display-4"><?php echo $duration_amount; ?></strong>
 			<span class="d-block text-uppercase text-nowrap font-weight-bold"><?php echo $duration_descriptor; ?></span>
 			<span class="d-block small"><?php echo $duration_notice; ?></span>
-			<span class="d-block small mt-4"><?php echo $credit_hours; ?> Credit Hours</span>
+			<span class="d-block mt-4"><span class="font-weight-bold"><?php echo $credit_hours; ?></span> Credit Hours</span>
 			<?php else: ?>
 			<strong class="d-block display-4"><?php echo $credit_hours; ?></strong>
 			<span class="d-block small text-uppercase text-nowrap">Credit Hours</span>

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -76,15 +76,14 @@ function online_get_degree_details_markup( $degree ) {
 
 
 /**
- * Returns HTML markup for a single degree's credit hour info.
+ * Returns HTML markup for a single degree's duration and credit hour info.
  *
  * @since 1.0.0
  * @author Jo Dickson
  * @param object $degree WP_Post object for a single degree
- * @return string HTML markup for a single degree's credit hour info
+ * @return string HTML markup for a single degree's duration and credit hour info
  */
-function online_get_degree_hours_markup( $degree ) {
-	$credit_hours = get_field( 'degree_hours', $degree );
+function online_get_degree_duration_markup( $degree ) {
 
 	ob_start();
 	if ( $credit_hours ):

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -84,15 +84,30 @@ function online_get_degree_details_markup( $degree ) {
  * @return string HTML markup for a single degree's duration and credit hour info
  */
 function online_get_degree_duration_markup( $degree ) {
+	$credit_hours      = get_field( 'degree_hours', $degree );
+	$duration          = get_field( 'degree_duration', $degree );
+	$is_duration_set   = !empty( $duration['degree_duration_amount'] );
+	$font_icon_classes = ( $duration['degree_duration_font_icon_classes'] ?: 'fa fa-3x fa-desktop' );
 
 	ob_start();
 	if ( $credit_hours ):
 ?>
 	<div class="card h-100">
 		<div class="card-block text-center d-flex flex-column justify-content-center px-sm-4">
-			<span class="fa fa-3x fa-desktop text-primary mb-2" aria-hidden="true"></span>
+			<span class="<?php echo $font_icon_classes; ?> text-primary mb-2" aria-hidden="true"></span>
+			<?php if ( $credit_hours && $is_duration_set ):
+				$duration_amount     = $duration['degree_duration_amount'];
+				$duration_descriptor = ( $duration['degree_duration_descriptor'] ?: 'Months' );
+				$duration_notice     = ( $duration['degree_duration_notice'] ?: 'Approx. program length' );
+			?>
+			<strong class="d-block display-4"><?php echo $duration_amount; ?></strong>
+			<span class="d-block text-uppercase text-nowrap font-weight-bold"><?php echo $duration_descriptor; ?></span>
+			<span class="d-block small"><?php echo $duration_notice; ?></span>
+			<span class="d-block small mt-4"><?php echo $credit_hours; ?> Credit Hours</span>
+			<?php else: ?>
 			<strong class="d-block display-4"><?php echo $credit_hours; ?></strong>
 			<span class="d-block small text-uppercase text-nowrap">Credit Hours</span>
+			<?php endif; ?>
 		</div>
 	</div>
 <?php

--- a/single-degree.php
+++ b/single-degree.php
@@ -5,7 +5,7 @@ $post = ucf_degree_append_meta( $post );
 
 // Degree data markup
 $details       = online_get_degree_details_markup( $post );
-$credit_hours  = online_get_degree_hours_markup( $post );
+$duration      = online_get_degree_duration_markup( $post );
 $tuition       = online_get_degree_tuition_markup( $post );
 $badges        = online_get_degree_badges_markup( $post );
 $career_paths  = online_get_degree_career_paths_markup( $post );
@@ -15,7 +15,7 @@ $video_caption = online_get_degree_video_caption_markup( $post );
 $spotlight     = online_get_degree_spotlight_markup( $post );
 
 // Helper variables
-$has_at_a_glance = ( $details || $credit_hours || $tuition || $badges );
+$has_at_a_glance = ( $details || $duration || $tuition || $badges );
 $has_sidebar     = ( $career_paths || $quotes || $video );
 ?>
 
@@ -34,9 +34,9 @@ $has_sidebar     = ( $career_paths || $quotes || $video );
 				</div>
 				<?php endif; ?>
 
-				<?php if ( $credit_hours ): ?>
+				<?php if ( $duration ): ?>
 				<div class="col-auto mb-4 mb-lg-0">
-					<?php echo $credit_hours; ?>
+					<?php echo $duration; ?>
 				</div>
 				<?php endif; ?>
 


### PR DESCRIPTION
**Description**
Adds the 'Degree Duration' ACF field group with fields that enable entering custom degree duration information to the 'Program at a Glance' 'Credit Hours' block. If this info is set, it replaces the default Credit Hours markup inside of that card block.

**Motivation and Context**
The Online team wanted to have a way to add degree length/duration information to the Credit Hours block, and make it customizable (including the font awesome icon classes, amount, amount descriptor and small blurb under that). I tried to keep all functionality work as it did before, so that degree pages that only have the Credit Hours value set will not look any different.
Other Notes:
- I renamed the `online_get_degree_hours_markup()` function to `online_get_degree_duration_markup()` since it's now not only returning credit hours information.

**How Has This Been Tested?**
Changes are viewable in dev. See links in Slack.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
