### PR TITLE
Add new Custom landing page template

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -846,6 +846,104 @@
         "description": ""
     },
     {
+        "key": "group_5d9215b4d46b6",
+        "title": "Landing Page Fields - Custom Template",
+        "fields": [
+            {
+                "key": "field_5d9215cce512c",
+                "label": "Header Content",
+                "name": "landing_custom_header_content",
+                "type": "wysiwyg",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            },
+            {
+                "key": "field_5d939a38a2c74",
+                "label": "Footer Content - Type of Content",
+                "name": "landing_custom_footer_content_type",
+                "type": "radio",
+                "instructions": "Specify the type of content that should be displayed within the footer.  Choose \"Default\" to display UCF's Signature & Pegasus logo on top of a black bar, or choose \"Custom Content\" to add any arbitrary content inside of the <code>&lt;footer&gt;<\/code> tag.",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "default": "Default",
+                    "custom": "Custom Content"
+                },
+                "allow_null": 0,
+                "other_choice": 0,
+                "default_value": "default",
+                "layout": "vertical",
+                "return_format": "value",
+                "save_other_choice": 0
+            },
+            {
+                "key": "field_5d93a301ef633",
+                "label": "Footer Custom Content",
+                "name": "landing_custom_footer_custom_content",
+                "type": "wysiwyg",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5d939a38a2c74",
+                            "operator": "==",
+                            "value": "custom"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "landing"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "template-landing-custom.php"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
         "key": "group_5c6d5cecd4d32",
         "title": "Landing Page Nav Fields",
         "fields": [

--- a/includes/footer-functions.php
+++ b/includes/footer-functions.php
@@ -14,8 +14,11 @@
  * @return string The footer type name
  */
 function online_get_footer_type( $footer_type, $obj ) {
-	if ( $obj instanceof WP_Post && $obj->post_type === 'landing' ) {
-		if ( ( get_post_meta( $obj->ID, '_wp_page_template', true ) === 'template-landing-custom.php' ) && ( get_field( 'landing_custom_footer_content_type', $obj ) === 'custom' ) ) {
+	if ($obj instanceof WP_Post && $obj->post_type === 'landing' ) {
+		if (
+			get_post_meta( $obj->ID, '_wp_page_template', true ) === 'template-landing-custom.php'
+			&& get_field( 'landing_custom_footer_content_type', $obj ) === 'custom'
+		) {
 			$footer_type = 'landing_custom';
 		} else {
 			$footer_type = 'landing';

--- a/includes/footer-functions.php
+++ b/includes/footer-functions.php
@@ -14,7 +14,7 @@
  * @return string The footer type name
  */
 function online_get_footer_type( $footer_type, $obj ) {
-	if ($obj instanceof WP_Post && $obj->post_type === 'landing' ) {
+	if ( $obj instanceof WP_Post && $obj->post_type === 'landing' ) {
 		if (
 			get_post_meta( $obj->ID, '_wp_page_template', true ) === 'template-landing-custom.php'
 			&& get_field( 'landing_custom_footer_content_type', $obj ) === 'custom'

--- a/includes/footer-functions.php
+++ b/includes/footer-functions.php
@@ -15,7 +15,11 @@
  */
 function online_get_footer_type( $footer_type, $obj ) {
 	if ( $obj instanceof WP_Post && $obj->post_type === 'landing' ) {
-		$footer_type = 'landing';
+		if ( ( get_post_meta( $obj->ID, '_wp_page_template', true ) === 'template-landing-custom.php' ) && ( get_field( 'landing_custom_footer_content_type', $obj ) === 'custom' ) ) {
+			$footer_type = 'landing_custom';
+		} else {
+			$footer_type = 'landing';
+		}
 	}
 
 	return $footer_type;

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -57,6 +57,9 @@ function online_get_header_type( $header_type, $obj ) {
 			case 'template-landing-3.php':
 				$header_type .= '_3';
 				break;
+			case 'template-landing-custom.php':
+				$header_type .= '_custom';
+				break;
 			case 'default':
 			default:
 				break;
@@ -99,6 +102,9 @@ function online_get_header_content_type( $content_type, $obj ) {
 				break;
 			case 'template-landing-3.php':
 				$content_type .= '_3';
+				break;
+			case 'template-landing-custom.php':
+				$content_type .= '_custom';
 				break;
 			case 'default':
 			default:

--- a/template-landing-custom.php
+++ b/template-landing-custom.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Template Name: Landing Page Custom
+ * Template Post Type: landing
+ */
+?>
+
+<?php get_header(); the_post(); ?>
+
+<article class="<?php echo $post->post_status; ?> post-list-item">
+	<?php the_content(); ?>
+</article>
+
+<?php get_footer(); ?>

--- a/template-parts/footer-landing_custom.php
+++ b/template-parts/footer-landing_custom.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Footer template used when necessary for Custom Landing Pages
+ */
+
+$obj     = ucfwp_get_queried_object();
+$content = get_field( 'landing_custom_footer_custom_content', $obj ) ?: '';
+?>
+<footer class="site-footer">
+	<?php echo $content; ?>
+</footer>

--- a/template-parts/footer-landing_custom.php
+++ b/template-parts/footer-landing_custom.php
@@ -5,7 +5,10 @@
 
 $obj     = ucfwp_get_queried_object();
 $content = get_field( 'landing_custom_footer_custom_content', $obj ) ?: '';
+
+if ( $content ) :
 ?>
 <footer class="site-footer">
 	<?php echo $content; ?>
 </footer>
+<?php endif; ?>

--- a/template-parts/header-landing_custom.php
+++ b/template-parts/header-landing_custom.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Header template for the Custom Landing Page Template
+ */
+?>
+
+<?php echo ucfwp_get_header_content_markup(); ?>

--- a/template-parts/header_content-landing_custom.php
+++ b/template-parts/header_content-landing_custom.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Inner header contents for the Custom Landing Page template
+ */
+
+$obj     = ucfwp_get_queried_object();
+$content = get_field( 'landing_custom_header_content', $obj ) ?: '';
+
+if ( $content ) :
+?>
+<div class="header-content-inner">
+	<?php echo $content; ?>
+</div>
+<?php endif; ?>


### PR DESCRIPTION
**Description**
Adds the 'Custom' landing page template, custom fields, and logic to return the new template parts based on the selection of this new template. 
- Adds new ACF fields for this custom template. These are to insert the custom header content and to either display the 'black bar' footer or custom footer content.

**Motivation and Context**
This template is necessary for landing pages that will have custom content and layouts, different than that of the current templates. It specifically will be used for the new Online landing page that will need to be produced in this manner.

**How Has This Been Tested?**
Changes are in dev.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
   _There's currently an open issue for adding the landing page documentation: https://github.com/UCF/Online-Child-Theme/issues/75_ 
