### PR TITLE
Removed custom handlebars/typeahead inclusion

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -13,9 +13,6 @@ function online_enqueue_frontend_assets() {
 	wp_enqueue_style( 'style-child', ONLINE_THEME_CSS_URL . '/style.min.css', array( 'style' ), $theme_version );
 	wp_enqueue_script( 'script-child', ONLINE_THEME_JS_URL . '/script.min.js', array( 'jquery', 'script', 'ucf-degree-search-js' ), $theme_version, true );
 
-	wp_register_script( 'typeaheadjs', 'https://cdnjs.cloudflare.com/ajax/libs/corejs-typeahead/1.0.1/typeahead.bundle.min.js', array( 'jquery' ), null, false );
-	wp_register_script( 'handlebars', 'https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/handlebars.min.js', null, null, false );
-
 	global $post;
 
 	if ( $post && $post->post_type === 'landing' ) {
@@ -24,31 +21,3 @@ function online_enqueue_frontend_assets() {
 }
 
 add_action( 'wp_enqueue_scripts', 'online_enqueue_frontend_assets', 11, 0 );
-
-
-/**
- * Modify settings for supported plugins to prevent duplicate registration and
- * enqueuing of assets.
- *
- * Adapted from Online-Theme
- */
-
-function online_post_list_js_deps( $deps ) {
-	return array( 'jquery', 'typeaheadjs', 'handlebars' );
-}
-
-add_filter( 'ucf_post_list_js_deps', 'online_post_list_js_deps', 10, 1 );
-
-
-if ( filter_var( get_option( 'ucf_post_list_include_js_libs' ), FILTER_VALIDATE_BOOLEAN ) !== false ) {
-	update_option( 'ucf_post_list_include_js_libs', false );
-}
-if ( filter_var( get_option( 'ucf_post_list_include_js' ), FILTER_VALIDATE_BOOLEAN ) !== true ) {
-	update_option( 'ucf_post_list_include_js', true );
-}
-if ( filter_var( get_option( 'ucf_degree_search_include_typeahead' ), FILTER_VALIDATE_BOOLEAN ) !== false ) {
-	update_option( 'ucf_degree_search_include_typeahead', false );
-}
-if ( filter_var( get_option( 'ucf_degree_search_auto_initialize' ), FILTER_VALIDATE_BOOLEAN ) !== false ) {
-	update_option( 'ucf_degree_search_auto_initialize', false );
-}


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These overrides result in breakage of degree search typeaheads when running the newest versions of these plugins.  Now that each plugin shares consistent typeahead/handlebars script handles and conditionally loads each dependency when needed, the overrides in this theme are no longer necessary.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev, after manually adjusting the previously-overridden settings back to default values.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly. https://github.com/UCF/Online-Child-Theme/wiki/Installation#required-plugins
