### PR TITLE
Remove Extra Modal

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -11,7 +11,7 @@ function online_enqueue_frontend_assets() {
 	$theme_version = $theme->get( 'Version' );
 
 	wp_enqueue_style( 'style-child', ONLINE_THEME_CSS_URL . '/style.min.css', array( 'style' ), $theme_version );
-	wp_enqueue_script( 'script-child', ONLINE_THEME_JS_URL . '/script.min.js', array( 'jquery', 'script', 'ucf-degree-search-js' ), $theme_version, true );
+	wp_enqueue_script( 'script-child', ONLINE_THEME_JS_URL . '/script.min.js', array( 'jquery', 'script', 'ucf-degree-search-js', 'ucf-degree-picker-js' ), $theme_version, true );
 
 	global $post;
 

--- a/single-degree-acf.php
+++ b/single-degree-acf.php
@@ -22,7 +22,6 @@
 	get_template_part( 'template-parts/degree/news' );
 
 	get_template_part( 'template-parts/degree/catalog_modal' );
-	get_template_part( 'template-parts/degree/request_info_modal' );
 ?>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Resolved #165 . Removes the additional modal that lives on the ACF template. Also ensures the degree picker is set as a dependency for the theme script.

**Motivation and Context**
We only want one modal.

**How Has This Been Tested?**
Changes are available for review in DEV and QA. Open the dev console, and execute `$('#gform_1'); `. You should only see one form on the page.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
