### PR TITLE
Pull header alt image

### DIFF
--- a/template-parts/header-landing_2.php
+++ b/template-parts/header-landing_2.php
@@ -7,6 +7,18 @@ $obj        = ucfwp_get_queried_object();
 $videos     = ucfwp_get_header_videos( $obj );
 $images     = ucfwp_get_header_images( $obj );
 $video_loop = get_field( 'page_header_video_loop', $obj );
+
+// We capture the image alt text from the first image in the header images array.
+if ( ! empty( $images ) ) { // Ensure $images is not empty
+    foreach ( $images as $image_id ) {
+        $image_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+        if ( ! empty( $image_alt ) ) {
+            break; // Exit the loop if a non-empty alt text is found
+        }
+    }
+}
+
+
 ?>
 <div class="header-media header-media-fluid bg-faded mb-0 d-flex flex-column">
 	<div class="header-media-background-wrap hidden-sm-down">
@@ -19,7 +31,7 @@ $video_loop = get_field( 'page_header_video_loop', $obj );
 			}
 			if ( $images ) {
 				$bg_image_srcs = ucfwp_get_header_media_picture_srcs( 'header-media-default', $images );
-				echo ucfwp_get_media_background_picture( $bg_image_srcs );
+				echo ucfwp_get_media_background_picture( $bg_image_srcs, $image_alt );
 			}
 			?>
 		</div>

--- a/template-parts/header-landing_2.php
+++ b/template-parts/header-landing_2.php
@@ -7,6 +7,7 @@ $obj        = ucfwp_get_queried_object();
 $videos     = ucfwp_get_header_videos( $obj );
 $images     = ucfwp_get_header_images( $obj );
 $video_loop = get_field( 'page_header_video_loop', $obj );
+$image_alt = ''; // Default value assigned here
 
 // We capture the image alt text from the first image in the header images array.
 if ( ! empty( $images ) ) { // Ensure $images is not empty

--- a/template-parts/header-landing_3.php
+++ b/template-parts/header-landing_3.php
@@ -7,6 +7,7 @@ $obj        = ucfwp_get_queried_object();
 $videos     = ucfwp_get_header_videos( $obj );
 $images     = ucfwp_get_header_images( $obj );
 $video_loop = get_field( 'page_header_video_loop', $obj );
+$image_alt = ''; // Default value assigned here
 
 // We capture the image alt text from the first image in the header images array.
 if ( ! empty( $images ) ) { // Ensure $images is not empty

--- a/template-parts/header-landing_3.php
+++ b/template-parts/header-landing_3.php
@@ -7,6 +7,16 @@ $obj        = ucfwp_get_queried_object();
 $videos     = ucfwp_get_header_videos( $obj );
 $images     = ucfwp_get_header_images( $obj );
 $video_loop = get_field( 'page_header_video_loop', $obj );
+
+// We capture the image alt text from the first image in the header images array.
+if ( ! empty( $images ) ) { // Ensure $images is not empty
+    foreach ( $images as $image_id ) {
+        $image_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+        if ( ! empty( $image_alt ) ) {
+            break; // Exit the loop if a non-empty alt text is found
+        }
+    }
+}
 ?>
 <div class="header-media header-media-fluid bg-faded mb-0 d-flex flex-column">
 	<div class="header-media-background-wrap hidden-sm-down">
@@ -19,7 +29,7 @@ $video_loop = get_field( 'page_header_video_loop', $obj );
 			}
 			if ( $images ) {
 				$bg_image_srcs = ucfwp_get_header_media_picture_srcs( 'header-media-default', $images );
-				echo ucfwp_get_media_background_picture( $bg_image_srcs );
+				echo ucfwp_get_media_background_picture( $bg_image_srcs, $image_alt );
 			}
 			?>
 		</div>

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -24,11 +24,6 @@ if ( ! empty( $images ) ) { // Ensure $images is not empty
     }
 }
 
-// If no alt text is found, use the fallback value
-if ( empty( $image_alt ) && ! empty( $images ) ) {
-    $image_alt = 'header background image';
-}
-
 
 // We modify the header's text color using bg utilities to make sure we
 // still meet color contrast req's when bg imgs/videos fail to load

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -13,8 +13,6 @@ $header_height       = get_field( 'page_header_height', $obj ) ?: 'header-media-
 $image_alt           = '';
 
 // We are capturing the image alt text from the first image in the header images array.
-// If no alt text is found, we will use a fallback value.
-
 if ( ! empty( $images ) ) { // Ensure $images is not empty
     foreach ( $images as $image_id ) {
         $image_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -12,7 +12,7 @@ $header_content_type = ucfwp_get_header_content_type( $obj );
 $header_height       = get_field( 'page_header_height', $obj ) ?: 'header-media-default'; // for imported, unmodified pages
 $image_alt           = '';
 
-// We are capturing the image alt text from the first image in the header images array.
+// We capture the image alt text from the first image in the header images array.
 if ( ! empty( $images ) ) { // Ensure $images is not empty
     foreach ( $images as $image_id ) {
         $image_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
@@ -21,7 +21,6 @@ if ( ! empty( $images ) ) { // Ensure $images is not empty
         }
     }
 }
-
 
 // We modify the header's text color using bg utilities to make sure we
 // still meet color contrast req's when bg imgs/videos fail to load

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -10,6 +10,25 @@ $video_loop = get_field( 'page_header_video_loop', $obj );
 $header_text_color   = get_field( 'page_header_text_color', $obj );
 $header_content_type = ucfwp_get_header_content_type( $obj );
 $header_height       = get_field( 'page_header_height', $obj ) ?: 'header-media-default'; // for imported, unmodified pages
+$image_alt           = '';
+
+// We are capturing the image alt text from the first image in the header images array.
+// If no alt text is found, we will use a fallback value.
+
+if ( ! empty( $images ) ) { // Ensure $images is not empty
+    foreach ( $images as $image_id ) {
+        $image_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+        if ( ! empty( $image_alt ) ) {
+            break; // Exit the loop if a non-empty alt text is found
+        }
+    }
+}
+
+// If no alt text is found, use the fallback value
+if ( empty( $image_alt ) && ! empty( $images ) ) {
+    $image_alt = 'header background image';
+}
+
 
 // We modify the header's text color using bg utilities to make sure we
 // still meet color contrast req's when bg imgs/videos fail to load
@@ -33,7 +52,7 @@ switch ( $header_text_color ) {
 			}
 			if ( $images ) {
 				$bg_image_srcs = ucfwp_get_header_media_picture_srcs( $header_height, $images );
-				echo ucfwp_get_media_background_picture( $bg_image_srcs );
+				echo ucfwp_get_media_background_picture( $bg_image_srcs, $image_alt );
 			}
 			?>
 		</div>


### PR DESCRIPTION
**Description**
Since we are using "picture" and "source" tags, we only need to pull one alt text and assign it to the fallback <img> tag. To achieve this, we loop through all the images registered in the theme. The first available alt text found (whether from the large or extra-small image) will be stored in the $alt_image variable, which is then passed as an argument to the ucfwp_get_media_background_picture function (defined in the UCF-WordPress-theme).

Because the function resides in the parent theme, I set a default value for the $alt_image variable there: "header background image" to serve as a fallback.

**Motivation and Context**
Alt tag is empty now and we want to fix this in order to increase accessibility

**How Has This Been Tested?**
Tested on Local.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
